### PR TITLE
Patch to work with freedesktop 18.08

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -3,7 +3,7 @@
     "base": "org.electronjs.Electron2.BaseApp",
     "base-version": "stable",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
+    "runtime-version": "unstable",
     "sdk": "org.freedesktop.Sdk",
     "command": "slack",
     "separate-locales": false,
@@ -28,7 +28,7 @@
                 "install slack.sh /app/bin/slack",
                 "install -Dm644 com.slack.Slack.appdata.xml /app/share/appdata/com.slack.Slack.appdata.xml",
                 "cp /usr/bin/ar /app/bin",
-                "cp /usr/lib/libbfd-*.so /app/lib"
+                "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so /app/lib"
             ],
             "sources" : [
                 {

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.slack.Slack",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "stable",
+    "base-version": "18.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "unstable",
+    "runtime-version": "18.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "slack",
     "separate-locales": false,


### PR DESCRIPTION
Freedesktop 18.08 works with multi-arch, so libraries are split out,
and libbfd has moved. This patch updates the copying of libbfd to
the new multi-arch system.

Obviously don't merge until freedesktop released as stable

Note: this is not backwards compatible with 1.6 as /usr/lib/{multiarch-triple}/libbfd.so doesn't exist in 1.6