### PR TITLE
Use Zypak for the sandbox (and update to 4.1.1)

### DIFF
--- a/com.slack.Slack.appdata.xml
+++ b/com.slack.Slack.appdata.xml
@@ -28,6 +28,20 @@
     <category>Network</category>
   </categories>
   <releases>
+    <release date="2019-10-08" version="4.1.1">
+      <description>
+        <p>What’s New</p>
+        <ul>
+          <li>Thanks to a few tweaks to the engine, a polish of the pistons, and recalibrated valves, the app should be running smoother and faster, than before.</li>	
+          <li>Spellcheck, revamped, is now a much better version of its old self (and back on Linux, to boot) — now it supports Greek, Portuguese and British English. So now spelling correctly should come more naturally to us all (which is good, because “correctly” can be a difacult word to spell). </li>	
+        </ul>
+        <p>Bug Fixes</p>
+        <ul>
+          <li>For a quicker connection, and less frustration, checking for network connectivity is more reliable than it was before. </li>	
+          <li>After uploading a video into Slack some found it would give an infinite circle of loading, but not play, which was never our plan. Now: it works! It plays; no more circle! Because, it turned out, all circ and no play made Slack a null ‘ploy.</li>	
+        </ul>
+      </description>
+    </release>
     <release date="2019-08-07" version="4.0.2">
       <description>
         <p>Bug Fixes:</p>

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -82,9 +82,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://downloads.slack-edge.com/linux_releases/slack-desktop-4.0.2-amd64.deb",
-                    "sha256": "75c26004ae56bbb944d4b97347b00bb28ff4042d10666490e7974613fc2d7214",
-                    "size": 61298592
+                    "url": "https://downloads.slack-edge.com/linux_releases/slack-desktop-4.1.1-amd64.deb",
+                    "sha256": "2e84af28a9179faf1a6c64e36e6316792531de1d4530fcd2909e5eae77d1ced9",
+                    "size": 57986912
                 }
             ]
         }

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -28,6 +28,16 @@
     ],
     "modules": [
         {
+            "name": "zypak",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/refi64/zypak",
+                    "tag": "v2019.11beta.3"
+                }
+            ]
+        },
+        {
             "name": "slack",
             "buildsystem": "simple",
             "build-commands": [
@@ -61,7 +71,7 @@
                     "type": "script",
                     "dest-filename": "slack.sh",
                     "commands": [
-                        "exec env TMPDIR=$XDG_CACHE_HOME /app/extra/bin/slack \"$@\""
+                        "exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/extra/bin/slack \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
**Do NOT merge this into master, please merge into a new beta branch instead!**

This PR adds support for keeping the sandbox via [zypak](https://github.com/refi64/zypak). Once everything is confirmed to be stable, I'll send another PR to a new zypak non-beta release, which should be ready to merge onto master. (You can also subscribe to release notifications for the zypak repository to watch future releases.)

(Wow, that's a lot of reverts.)