### PR TITLE
Register application menu into desktop environment

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -20,7 +20,8 @@
         "--filesystem=xdg-download",
         "--talk-name=org.freedesktop.Notifications",
         "--env=XDG_CURRENT_DESKTOP=Unity",
-        "--talk-name=org.kde.StatusNotifierWatcher"
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=com.canonical.AppMenu.Registrar"
     ],
     "modules": [
         {


### PR DESCRIPTION
Currently, the application doesn't register the menu into my desktop environment, so I added an additional finish-arg as it was stated in [Octave issue](https://github.com/flathub/org.octave.Octave/issues/6)

![image](https://user-images.githubusercontent.com/14634402/79068026-6bae9e80-7ccc-11ea-8c94-a0509d4b1cdd.png)
