### PR TITLE
Give Slack access to system /tmp

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -18,6 +18,7 @@
         "--filesystem=xdg-music:ro",
         "--filesystem=xdg-videos:ro",
         "--filesystem=xdg-download",
+        "--filesystem=/tmp"
         "--talk-name=org.freedesktop.Notifications",
         "--env=XDG_CURRENT_DESKTOP=Unity",
         "--talk-name=org.kde.StatusNotifierWatcher",


### PR DESCRIPTION
We often use /tmp to store temporary files, of cause... but flatpak Slack does not give access to this.

It was also a problem with GIMP, which they solved here https://github.com/flathub/org.gimp.GIMP/commit/bf7aff31ff6875dbab3cc53b300414ed01444c78 (issue: https://github.com/flathub/org.gimp.GIMP/issues/11) - could you possibly make the same correction?