### PR TITLE
Build with pipewire support to enable wayland screen sharing

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -35,7 +35,7 @@
                 "install -Dm644 slack.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png",
                 "install -Dm644 slack.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=\"Icon\" --set-value=\"com.slack.Slack\" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
-                "desktop-file-edit --set-key=\"Exec\" --set-value=\"slack %U\" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
+                "desktop-file-edit --set-key=\"Exec\" --set-value=\"slack --enable-features=WebRTCPipeWireCapturer %U\" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=\"StartupWMClass\" --set-value=\"Slack\" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=\"X-Flatpak-RenamedFrom\" --set-value=\"slack.desktop;\" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
                 "install -Dm755 /usr/bin/ar -t ${FLATPAK_DEST}/bin",

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -21,6 +21,7 @@
         "--talk-name=org.freedesktop.Notifications",
         "--env=XDG_CURRENT_DESKTOP=Unity",
         "--talk-name=org.kde.StatusNotifierWatcher",
+        "--filesystem=xdg-run/pipewire-0",
         "--talk-name=com.canonical.AppMenu.Registrar"
     ],
     "modules": [
@@ -91,6 +92,24 @@
                     }
                 }
             ]
+        },
+
+        {
+         "name": "pipewire",
+         "buildsystem": "meson",
+         "config-opts": [
+            "-Dgstreamer=disabled",
+            "-Dman=false",
+            "-Dsystemd=false"
+         ],
+         "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.freedesktop.org/pipewire/pipewire.git",
+                    "tag": "0.2.7"
+                }
+            ]
         }
     ]
 }
+


### PR DESCRIPTION
Add pipewire screen sharing support following chromium flatpak's example. Pipewire is necessary to get screen sharing with chromium on wayland, and works correctly now in flatpak with these changes. The feature works fairly well, aside from some relatively minor bugs. The core screen sharing functionality works and is stable.

This PR builds the pipewire module with the flatpak, and also adds a needed chromium pipewire flag to the .desktop file. This feature works out of the box with these fixes, and no manual configuration or flags are needed from end users. This addition does not regress more traditional screen sharing in x11, it should only improve the experience for wayland users (tested on fedora 34 and ubuntu 20.04, on wayland and x11).

Fixes #101

Current issues with this implementation:
- (Upstream issue) Pointer sometimes doesn't show up exactly where it should on my HIDPI setup. This is likely an upstream issue (I have noticed this with screen sharing in other apps).
- (Upstream issue) The 2 pipewire dialogs that pop up are a bit confusing and could confuse users. Only the second pipewire dialog actually does anything it seems, there is a first one which doesn't seem to actually have an effect. Sometimes only one dialog seems to appear, and that is the one that actually starts screen sharing. These are [known chromium issues](https://jgrulich.cz/2020/12/18/webrtc-chromium-updates-in-2020/).
- (Upstream issue) Also, slack adds its own extra dialog when sharing which is somewhat unecessary with pipewire support. However, it is only one extra click (you can click any of the display(s) slack lists).
- (Can't fix) "Draw on screen" doesn't work. This is likely a upstream issue and not something we can fix without fixing slack itself. (draw on screen does not work on x11 either, slack explictly says it is not supported on linux).
- (Solved) I would like to confirm the effect on x11 users. If it regresses I will ensure pipewire is only used on wayland. (no regression observed thankfully, you can share in x11 perfectly fine in my testing, pipewire isn't used)
- (Can't fix) I have no idea if audio screen sharing is something supported by slack in the first place, but for what it's worth I can't find an option for it via pipewire here. (not visible on x11 either, so it likely isn't on linux or even slack at all) 

Keep in mind the alternative on wayland with slack flatpak is to get no screen sharing at all. This is likely a "good enough" experience for most users. These bugs will likely get resolved as chromium, electron, slack and pipewire release updates.

This work is based off chromium flatpak, given that slack is already built with pipewire support (if slack wasn't built with pipewire support none of this would work). The only thing missing at buildtime were [the correct flatpak modules](https://github.com/flathub/com.slack.Slack/issues/101#issuecomment-808430530) and [a runtime flag](https://github.com/flathub/com.slack.Slack/issues/101#issuecomment-808430530).

Also note this PR does not and is not intended to enable wayland by default for slack. Enabling wayland by default may need a seperate PR or upstream effort.

This PR uses pipewire 0.2.x instead of the newer 0.3.x for the reasons [listed here](https://github.com/flathub/com.slack.Slack/pull/118#issuecomment-832429708). In short there is no obvious benefit to using 0.3.x for now, but this could definitely change in the future.

[See here for what seems to work for chromium](https://github.com/flathub/org.chromium.Chromium/pull/23/commits/ec9c48bcb837a522cc6217ac222f98ea3df1fb0b#) to solve [their screen sharing on wayland issue](https://github.com/flathub/org.chromium.Chromium/issues/22).