### PR TITLE
Use an alternative data-source as defined by main project

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -86,8 +86,8 @@
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://slack.com/intl/en-nl/downloads/instructions/ubuntu",
-                        "version-pattern": "Version ([\\d.-]+)",
-                        "url-pattern": "https://downloads.slack-edge.com/linux_releases/slack-desktop-$version-amd64.deb"
+                        "version-pattern": "https://downloads.slack-edge.com/linux_releases/slack-desktop-([\\d\\.]+)-amd64.deb",
+                        "url-pattern": "(https://downloads.slack-edge.com/linux_releases/slack-desktop-[\\d\\.]+-amd64.deb)"
                     }
                 }
             ]

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -80,15 +80,14 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://packagecloud.io/slacktechnologies/slack/debian/pool/jessie/main/s/slack-desktop/slack-desktop_4.17.0_amd64.deb",
+                    "url": "https://downloads.slack-edge.com/linux_releases/slack-desktop-4.17.0-amd64.deb",
                     "sha256": "b1e7123f9e51d292b647fecd42236f2de3b3f863c631e8278d47e08b8aae8c1d",
                     "size": 60979198,
                     "x-checker-data": {
-                        "type": "debian-repo",
-                        "package-name": "slack-desktop",
-                        "root": "https://packagecloud.io/slacktechnologies/slack/debian/",
-                        "dist": "jessie",
-                        "component": "main"
+                        "type": "html",
+                        "url": "https://slack.com/intl/en-nl/downloads/instructions/ubuntu",
+                        "version-pattern": "Version ([\\d.-]+)",
+                        "url-pattern": "https://downloads.slack-edge.com/linux_releases/slack-desktop-$version-amd64.deb"
                     }
                 }
             ]


### PR DESCRIPTION
@barthalion Hey, after this afternoon's incident, I've looked into the source-url and found a possibly better source: This is the one that they directly link on their website. I'm not sure what the impact will be if we change this in the long run, but at this time the files are identical so that's good.

As for the x-data-checker, I hope it works because webpage-scraping is always hit-and-miss.