### PR TITLE
Update pipewire to latest version

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -98,14 +98,19 @@
             "buildsystem": "meson",
             "config-opts": [
                 "-Dgstreamer=disabled",
-                "-Dman=false",
-                "-Dsystemd=false"
+                "-Dman=disabled",
+                "-Dsystemd=disabled",
+                "-Dudevrulesdir=/app/lib/udev/rules.d"
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://gitlab.freedesktop.org/pipewire/pipewire.git",
-                    "tag": "0.2.7"
+                    "tag": "0.3.31",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
Also include a x-data-checker config. The only thing that can be considered lacklustre is the discarding of the udev rules, but then again Slack is an application with full device access anyway.

@barthalion Sorry for bothering you so much today, but who is actually in charge of application bundles like these?