### PR TITLE
Remove PipeWire 0.3.x module

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -92,27 +92,6 @@
                     }
                 }
             ]
-        },
-        {
-            "name": "pipewire",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Dgstreamer=disabled",
-                "-Dman=disabled",
-                "-Dsystemd=disabled",
-                "-Dudevrulesdir=/app/lib/udev/rules.d"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.freedesktop.org/pipewire/pipewire.git",
-                    "tag": "0.3.31",
-                    "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^([\\d.]+)$"
-                    }
-                }
-            ]
         }
     ]
 }


### PR DESCRIPTION
This isn't necessary in the first place as PipeWire 0.3.x is included in the 20.08 FreeDesktop runtime. [Chromium Flatpak uses PipeWire included in the runtime](https://github.com/flathub/org.chromium.Chromium/blob/master/org.chromium.Chromium.yaml) and screen sharing works.

In the past we needed to add PipeWire 0.2.x as Electron<13 defaulted to only have support for PipeWire 0.2.x for screen sharing on Wayland.

According to Slack's logs (accessible via DEB/RPM) Slack should be on Electron 13/Chromium 91, so we no longer need to add PipeWire 0.2.x like in https://github.com/flathub/com.slack.Slack/pull/118.

We should still test screen sharing on Wayland though. If anyone has a paid Slack account (necessary for screen sharing) please test this branch.

See https://github.com/flathub/com.slack.Slack/pull/133

Makes #134 and #136 uneccessary.