### PR TITLE
Run natively on Wayland when available

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -35,7 +35,7 @@
                 "install -Dm644 slack.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png",
                 "install -Dm644 slack.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=\"Icon\" --set-value=\"com.slack.Slack\" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
-                "desktop-file-edit --set-key=\"Exec\" --set-value=\"slack --enable-features=WebRTCPipeWireCapturer %U\" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
+                "desktop-file-edit --set-key=\"Exec\" --set-value=\"slack %U\" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=\"StartupWMClass\" --set-value=\"Slack\" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
                 "desktop-file-edit --set-key=\"X-Flatpak-RenamedFrom\" --set-value=\"slack.desktop;\" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
                 "install -Dm755 /usr/bin/ar -t ${FLATPAK_DEST}/bin",
@@ -62,6 +62,8 @@
                         "EXTRA_ARGS=\"\"",
                         "if [ -z \"$DISPLAY\" ] && [ -n \"$WAYLAND_DISPLAY\" ]; then",
                         "EXTRA_ARGS=\"--enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland\"",
+                        "else",
+                        "EXTRA_ARGS=\"--enable-features=WebRTCPipeWireCapturer\"",
                         "fi",
                         "exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/extra/bin/slack -s $EXTRA_ARGS \"$@\""
                     ]

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -61,7 +61,7 @@
                     "commands": [
                         "EXTRA_ARGS=\"\"",
                         "if [ -z \"$DISPLAY\" ] && [ -n \"$WAYLAND_DISPLAY\" ]; then",
-                        "EXTRA_ARGS=\"--enable-features=UseOzonePlatform --ozone-platform=wayland\"",
+                        "EXTRA_ARGS=\"--enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland\"",
                         "fi",
                         "exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/extra/bin/slack -s $EXTRA_ARGS \"$@\""
                     ]

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -59,7 +59,11 @@
                     "type": "script",
                     "dest-filename": "slack.sh",
                     "commands": [
-                        "exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/extra/bin/slack -s \"$@\""
+                        "EXTRA_ARGS=\"\"",
+                        "if [ -z \"$DISPLAY\" ] && [ -n \"$WAYLAND_DISPLAY\" ]; then",
+                        "EXTRA_ARGS=\"--enable-features=UseOzonePlatform --ozone-platform=wayland\"",
+                        "fi",
+                        "exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/extra/bin/slack -s $EXTRA_ARGS \"$@\""
                     ]
                 },
                 {

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -59,7 +59,6 @@
                     "type": "script",
                     "dest-filename": "slack.sh",
                     "commands": [
-                        "EXTRA_ARGS=\"\"",
                         "if [ -z \"$DISPLAY\" ] && [ -n \"$WAYLAND_DISPLAY\" ]; then",
                         "EXTRA_ARGS=\"--enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland\"",
                         "else",


### PR DESCRIPTION
Currently when running on Wayland, slack will fall back to XWayland which results in blurry rendering (if it runs at all). There is no way to configure Slack to run on Wayland

This change forces Slack to run naively on Wayland but only if that's the only an option. That is, it'll only run on Wayland if the user configurs the overrides `sockets=wayland;!x11`.

