### PR TITLE
Fix automatic updates due to is-main-source not being boolean

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -93,7 +93,7 @@
                         "url": "https://slack.com/intl/en-nl/downloads/linux",
                         "version-pattern": "Version ([\\d\\.]+)",
                         "url-template": "https://downloads.slack-edge.com/releases/linux/$version/prod/x64/slack-desktop-$version-amd64.deb",
-                        "is-main-source": "true"
+                        "is-main-source": true
                     }
                 }
             ]


### PR DESCRIPTION
Previously, `flatpak-external-data-checker` was failing due to the `is-main-source` flag not being a boolean.