### PR TITLE
Restore GNOME/KDE tray icon

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -23,7 +23,7 @@
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--filesystem=xdg-run/pipewire-0",
         "--talk-name=com.canonical.AppMenu.Registrar",
-        "--own-name=org.kde.StatusNotifierItem-2-1"
+        "--own-name=org.kde.*"
     ],
     "modules": [
         {


### PR DESCRIPTION
It might work for other DEs, tested only on GNOME 44.

This issue was reported on multiple occasions after the v4.31.155 update:
#193 #198 #199