### PR TITLE
Revert Wayland changes and add additional permissions

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -55,7 +55,7 @@
                     "dest-filename": "slack.sh",
                     "commands": [
                         "if [ -z \"$DISPLAY\" ] && [ -n \"$WAYLAND_DISPLAY\" ]; then",
-                        "EXTRA_ARGS=\"--enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer --enable-wayland-ime --ozone-platform=wayland\"",
+                        "EXTRA_ARGS=\"--enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer --ozone-platform=wayland\"",
                         "else",
                         "EXTRA_ARGS=\"--enable-features=WebRTCPipeWireCapturer\"",
                         "fi",

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -10,14 +10,17 @@
     "finish-args": [
         "--share=ipc",
         "--socket=wayland",
-        "--socket=fallback-x11",
+        "--socket=x11",
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
+        "--system-talk-name=org.freedesktop.login1",
+        "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=com.canonical.AppMenu.Registrar",
         "--filesystem=xdg-run/pipewire-0",
-        "--talk-name=com.canonical.AppMenu.Registrar"
+        "--filesystem=xdg-download"
     ],
     "modules": [
         {

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -44,13 +44,10 @@
                     "type": "script",
                     "dest-filename": "apply_extra",
                     "commands": [
-                        "ar x slack.deb",
-                        "rm -f slack.deb",
-                        "tar xf data.tar.xz",
-                        "rm -f control.tar.gz data.tar.xz debian-binary",
-                        "mv usr/* .",
-                        "chmod -R a-s,go+rX,go-w .",
-                        "rmdir usr"
+                        "ar x slack.deb data.tar.xz",
+                        "rm slack.deb",
+                        "tar xf data.tar.xz --strip-components=4 ./usr/lib/slack",
+                        "rm data.tar.xz"
                     ]
                 },
                 {
@@ -62,7 +59,7 @@
                         "else",
                         "EXTRA_ARGS=\"--enable-features=WebRTCPipeWireCapturer\"",
                         "fi",
-                        "exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/extra/bin/slack -s $EXTRA_ARGS \"$@\""
+                        "exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/extra/slack -s $EXTRA_ARGS \"$@\""
                     ]
                 },
                 {

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -55,7 +55,7 @@
                     "dest-filename": "slack.sh",
                     "commands": [
                         "if [ -z \"$DISPLAY\" ] && [ -n \"$WAYLAND_DISPLAY\" ]; then",
-                        "EXTRA_ARGS=\"--enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer --ozone-platform=wayland\"",
+                        "EXTRA_ARGS=\"--enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland\"",
                         "else",
                         "EXTRA_ARGS=\"--enable-features=WebRTCPipeWireCapturer\"",
                         "fi",


### PR DESCRIPTION
* Revert wayland by default (fixes #212, #211, #210)
* Address missing dbus permissions. Slack now requires access to session secrets manager and system login dbus interfaces. Add `xdg-download` permissions to fix file downloads not appearing in the download folder (fixes #202, #193)
* Flatten the /app/extra hierarchy to remove unnecessary files