### PR TITLE
Check for new releases in Slack release-notes page

### DIFF
--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -85,8 +85,8 @@
                     "size": 78115758,
                     "x-checker-data": {
                         "type": "html",
-                        "url": "https://slack.com/intl/en-nl/downloads/linux",
-                        "version-pattern": "Version ([\\d\\.]+)",
+                        "url": "https://slack.com/intl/en-gb/release-notes/linux",
+                        "version-pattern": "Slack (\\d+\\.\\d+\\.\\d+)",
                         "url-template": "https://downloads.slack-edge.com/releases/linux/$version/prod/x64/slack-desktop-$version-amd64.deb",
                         "is-main-source": true
                     }


### PR DESCRIPTION
It seems that the release-notes page[1] is more up-to-date than the download page[2] for the Linux client. Use that instead as source for checking if new releases are available.

Fixes #218

[1]: https://slack.com/intl/en-gb/release-notes/linux
[2]: https://slack.com/intl/en-gb/downloads/linux