### PR TITLE
Default to using X11, leave an opt in for users that want to use Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Slack
+
+Slack is a messaging app for business that connects people to the information they need.
+
+This repo hosts the flatpak wrapper for [Slack](https://slack.com/), available at [Flathub](https://flathub.org/apps/details/com.slack.Slack).
+
+```sh
+flatpak install flathub com.slack.Slack
+flatpak run com.slack.Slack
+```

--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ This repo hosts the flatpak wrapper for [Slack](https://slack.com/), available a
 flatpak install flathub com.slack.Slack
 flatpak run com.slack.Slack
 ```
+
+### Wayland
+
+This package enables the flags to run on Wayland, however it is opt-in. To opt-in run:
+
+```sh
+flatpak override --user --socket=wayland com.slack.Slack
+```
+
+To opt-out do the same with `--nosocket=wayland`.

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -23,7 +23,8 @@
         "--talk-name=org.kde.kwalletd5",
         "--talk-name=org.kde.kwalletd6",
         "--talk-name=com.canonical.AppMenu.Registrar",
-        "--filesystem=xdg-download"
+        "--filesystem=xdg-download",
+        "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"
     ],
     "modules": [
         {

--- a/com.slack.Slack.json
+++ b/com.slack.Slack.json
@@ -9,7 +9,6 @@
     "separate-locales": false,
     "finish-args": [
         "--share=ipc",
-        "--socket=wayland",
         "--socket=x11",
         "--socket=pulseaudio",
         "--share=network",
@@ -52,16 +51,8 @@
                     ]
                 },
                 {
-                    "type": "script",
-                    "dest-filename": "slack.sh",
-                    "commands": [
-                        "if [ -z \"$DISPLAY\" ] && [ -n \"$WAYLAND_DISPLAY\" ]; then",
-                        "EXTRA_ARGS=\"--enable-features=UseOzonePlatform,WebRTCPipeWireCapturer --ozone-platform=wayland\"",
-                        "else",
-                        "EXTRA_ARGS=\"--enable-features=WebRTCPipeWireCapturer\"",
-                        "fi",
-                        "exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/extra/slack -s $EXTRA_ARGS \"$@\""
-                    ]
+                    "type": "file",
+                    "path": "slack.sh"
                 },
                 {
                     "type": "file",

--- a/slack.sh
+++ b/slack.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
+
+EXTRA_ARGS='--enable-features=WebRTCPipeWireCapturer'
+
+if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_SOCKET}" ]]
+then
+    EXTRA_ARGS="${EXTRA_ARGS} --enable-wayland-ime --ozone-platform-hint=auto"
+fi
+
+env TMPDIR=${XDG_CACHE_HOME} zypak-wrapper /app/extra/slack -s ${EXTRA_ARGS} "$@"


### PR DESCRIPTION
Slack is not currently in a state where Wayland by default is
acceptable, see #212.
    
Allow the user to enable the Wayland socket if they are willing to
accept the feature incomplete window decorations, and other issues.
    
Notably enabling Wayland fixes the app looking blurry when running
under XWayland.

Also fixes the cursor being cut in half when running Slack with Wayland.