### PR TITLE
Update app screenshot from https://slack.com/downloads/linux

### DIFF
--- a/com.slack.Slack.appdata.xml
+++ b/com.slack.Slack.appdata.xml
@@ -25,7 +25,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://a.slack-edge.com/d3446a3/marketing/img/downloads/refreshed/slack-ia4-client-linux-desktop.en-GB@2x.png</image>
+      <image type="source">https://a.slack-edge.com/6e36e01/marketing/img/downloads/refreshed/slack-ia4-client-linux-desktop@2x.png</image>
     </screenshot>
   </screenshots>
   <categories>


### PR DESCRIPTION
This should fix the issues FlatHub had with "Just the app window" since the original screenshot had two white bars at the bottom.