### PR TITLE
Fix crashing due to background permissions, add lsb_release for debugging, update Slack to 4.36.140

### DIFF
--- a/com.slack.Slack.metainfo.xml
+++ b/com.slack.Slack.metainfo.xml
@@ -71,6 +71,12 @@
 
   <!-- Contents are from https://slack.com/release-notes/linux -->
   <releases>
+    <release version="4.36.140" date="2024-01-24">
+      <description>
+        <p>We tuned up the engine and gave the interiors a thorough clean. Everything
+        is now running smoothly again.</p>
+      </description>
+    </release>
     <release version="4.36.138" date="2024-01-16">
       <description>
         <p>All bugs that were fixed in this release were too small for the eye to

--- a/com.slack.Slack.yaml
+++ b/com.slack.Slack.yaml
@@ -61,9 +61,9 @@ modules:
       - type: extra-data
         filename: slack.deb
         only-arches: [x86_64]
-        url: https://downloads.slack-edge.com/releases/linux/4.36.138/prod/x64/slack-desktop-4.36.138-amd64.deb
-        sha256: 4f5b1eb378d5a58a364f9dc70df5c0ccd9be0cedbab42df7193ddfbb1d2a021a
-        size: 78691946
+        url: https://downloads.slack-edge.com/releases/linux/4.36.140/prod/x64/slack-desktop-4.36.140-amd64.deb
+        sha256: b90f363faf735987231b653756d7bffa0e5e328e6254551d6cbd85c52e84507d
+        size: 78738834
         x-checker-data:
           is-main-source: true
           type: html

--- a/com.slack.Slack.yaml
+++ b/com.slack.Slack.yaml
@@ -30,6 +30,18 @@ finish-args:
   - --system-talk-name=org.freedesktop.UPower
   - --system-talk-name=org.freedesktop.login1
 modules:
+  - name: lsb_release
+    buildsystem: simple
+    cleanup:
+      - /share/man
+    build-commands:
+      - make
+      - make install INSTALL_ROOT=${FLATPAK_DEST}
+    sources:
+      - type: git
+        url: https://github.com/thkukuk/lsb-release_os-release.git
+        tag: v3.3
+
   - name: slack
     buildsystem: simple
     build-commands:

--- a/com.slack.Slack.yaml
+++ b/com.slack.Slack.yaml
@@ -39,6 +39,8 @@ modules:
       - install -Dm755 slack.sh ${FLATPAK_DEST}/bin/${FLATPAK_ID}
       - install -Dm644 slack.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
 
+      - desktop-file-edit --remove-key="StartupNotify" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+
       # Edit desktop file to remap to our ${FLATPAK_ID}.
       - desktop-file-edit --set-icon="${FLATPAK_ID}" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
       - desktop-file-edit --set-key="Exec" --set-value="${FLATPAK_ID} %U" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop


### PR DESCRIPTION
xdg-desktop-portal is killing Slack on startup after around 5 seconds, it appears to be related to the following issue:
https://github.com/flatpak/xdg-desktop-portal/issues/1010

According to the desktop entry spec, if this is absent reasonable handling is up to implementations, so it'll use StartupWMClass instead to track the application startup.

Fixes: #251
Test: Disable running in background for Slack, observe as app does
      not get closed by xdg-desktop-portal.