### PR TITLE
Fix wayland detection in some systems

### DIFF
--- a/slack.sh
+++ b/slack.sh
@@ -2,7 +2,9 @@
 
 EXTRA_ARGS='--enable-features=WebRTCPipeWireCapturer'
 
-if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_SOCKET:-'wayland-0'}" || -e "${WAYLAND_DISPLAY}" ]]
+WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
+
+if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
 then
     EXTRA_ARGS="${EXTRA_ARGS} --enable-wayland-ime --ozone-platform-hint=auto"
 fi

--- a/slack.sh
+++ b/slack.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
-
 EXTRA_ARGS='--enable-features=WebRTCPipeWireCapturer'
 
-if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_SOCKET}" ]]
+if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-'wayland-0'}" || -e "${WAYLAND_SOCKET}" ]]
 then
     EXTRA_ARGS="${EXTRA_ARGS} --enable-wayland-ime --ozone-platform-hint=auto"
 fi

--- a/slack.sh
+++ b/slack.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-EXTRA_ARGS='--enable-features=WebRTCPipeWireCapturer'
-
 WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
+
+EXTRA_ARGS='--enable-features=WebRTCPipeWireCapturer'
 
 if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
 then

--- a/slack.sh
+++ b/slack.sh
@@ -2,7 +2,7 @@
 
 EXTRA_ARGS='--enable-features=WebRTCPipeWireCapturer'
 
-if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-'wayland-0'}" || -e "${WAYLAND_SOCKET}" ]]
+if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_SOCKET:-'wayland-0'}" || -e "${WAYLAND_DISPLAY}" ]]
 then
     EXTRA_ARGS="${EXTRA_ARGS} --enable-wayland-ime --ozone-platform-hint=auto"
 fi


### PR DESCRIPTION
Flatpak seems to be setting `${WAYLAND_DISPLAY}` to an absolute path in some systems. This was causing the wayland check to fail because we were looking for the wrong path. This change should support all cases now.