### PR TITLE
Adds branding colors

### DIFF
--- a/com.slack.Slack.metainfo.xml
+++ b/com.slack.Slack.metainfo.xml
@@ -822,4 +822,9 @@
       </description>
     </release>
   </releases>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#7e547e</color>
+    <color type="primary" scheme_preference="dark">#4a154b</color>
+  </branding>
 </component>


### PR DESCRIPTION
Main color is taken from https://brand.slackhq.com/color the lighter variant is taken from one of the illustrations on that page.

Should look something like this later

![image](https://github.com/flathub/com.slack.Slack/assets/5943908/386f3e68-543e-48c4-8e60-3349ad8f5ecf)


Did this by using https://brand-color-preview.vercel.app/