### PR TITLE
Switch to the snap stable channel

### DIFF
--- a/com.slack.Slack.yaml
+++ b/com.slack.Slack.yaml
@@ -89,7 +89,7 @@ modules:
         x-checker-data:
           type: snapcraft
           name: slack
-          channel: beta
+          channel: stable
       - type: file
         path: com.slack.Slack.metainfo.xml
       - type: file


### PR DESCRIPTION
The versions of the stable and beta channel are finally alligned so we can switch without logging users out.