### PR TITLE
Fix window decoration icon in KDE when in native Wayland mode

### DIFF
--- a/com.slack.Slack.yaml
+++ b/com.slack.Slack.yaml
@@ -104,3 +104,4 @@ modules:
           - unsquashfs -quiet -no-progress slack.snap usr/lib/slack
           - mv squashfs-root/usr/lib/slack/* .
           - rm -r squashfs-root slack.snap
+          - FLATPAK_ID=com.slack.Slack patch-desktop-filename resources/app.asar


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/198b3eba-280a-4ccc-8396-6f564d55410f)
