### PR TITLE
Enable text-input-v3 on wayland

### DIFF
--- a/slack.sh
+++ b/slack.sh
@@ -6,7 +6,7 @@ EXTRA_ARGS='--enable-features=WebRTCPipeWireCapturer'
 
 if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
 then
-    EXTRA_ARGS="${EXTRA_ARGS} --enable-wayland-ime --ozone-platform-hint=auto"
+    EXTRA_ARGS="${EXTRA_ARGS} --enable-wayland-ime --ozone-platform-hint=auto --wayland-text-input-version=3"
 fi
 
 env TMPDIR=${XDG_CACHE_HOME} XDG_DOWNLOAD_DIR=$(xdg-user-dir DOWNLOAD) zypak-wrapper /app/extra/slack -s ${EXTRA_ARGS} "$@"


### PR DESCRIPTION
This change allows wayland client to use the latest text-input-v3 protocol. Enabling input method on various compositors, including Mutter.