### PR TITLE
Enable fine grained control over notifications

### DIFF
--- a/com.slack.Slack.yaml
+++ b/com.slack.Slack.yaml
@@ -74,6 +74,7 @@ modules:
       - install -Dm644 slack.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
 
       - desktop-file-edit --remove-key="StartupNotify" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+      - desktop-file-edit --set-key="X-GNOME-UsesNotifications" --set-value="true" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
 
       # Edit desktop file to remap to our ${FLATPAK_ID}.
       - desktop-file-edit --set-icon="${FLATPAK_ID}" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop


### PR DESCRIPTION
DEs such as Gnome and KDE allow to configure desktop notifications per-application. To enable that, the following line should be present in the `.desktop` file:

```
X-GNOME-UsesNotifications=true
```

See https://developer.gnome.org/documentation/tutorials/notifications.html#disabling-notifications