### PR TITLE
slack.sh: Ensure existence of secret service

### DIFF
--- a/slack.sh
+++ b/slack.sh
@@ -9,4 +9,31 @@ then
     EXTRA_ARGS="${EXTRA_ARGS} --enable-wayland-ime --ozone-platform-hint=auto --wayland-text-input-version=3"
 fi
 
+# Check for the existence of the keyring before continuing, as the Slack token
+# is stored in a keyring, and when it cannot access the keyring it thinks the
+# session is destroyed and never tries the token from keyring again once it is
+# accessible. This can happen due to race in startup applications where the
+# secret service is provided by a non-DE program like keepassxc.
+#
+# If secret service exists, lookup for a non-existent entry fails silently.
+# But if it doesn't, there is an error printed.
+tries=3
+while (( $tries > 0 )); do
+    tries=$(( $tries - 1 ))
+    output=$(2>&1 secret-tool lookup anything_random_dont_use_this_key_fgd78gca6ft8wg9tr f7s8frslfjsdkfsfsgjfg)
+    if [[ "$output" == "" ]] || [[ $? == 0 ]]; then
+        break
+    fi
+    
+    >&2 printf "Cannot access keyring! "
+    
+    if (( $tries == 0 )); then
+        >&2 echo "Max tries exceeded, exiting."
+        exit 69  # UNAVAILABLE
+    fi
+
+    >&2 echo "Retrying after 5seconds..."
+    sleep 5
+done
+
 env TMPDIR=${XDG_CACHE_HOME} XDG_DOWNLOAD_DIR=$(xdg-user-dir DOWNLOAD) zypak-wrapper /app/extra/slack -s ${EXTRA_ARGS} "$@"


### PR DESCRIPTION
Slack stores its token in the keyring and reads from it at application start (in the same way as chromium).

We can have cases where the secret service does not exist at some point of time, because the keyring provider is another non-DE program, like keepassxc.

And this can especially happen on startup - both keepassxc and Slack would be startup applications, and there is no ordering enforced by (let's say) GNOME.

Keyring is available for access only when keepassxc gets started. So it must start earlier. But due to lack of ordering, Slack could start before keepassxc.

Since Slack won the race, it can't use the secret service (i.e. the keyring access would fail), and thus can't see the token.

When that happens, Slack resets the session. And even upon subsequent availability of the secret service, Slack does not restore the session, even after gaining access to the keyring / token - the destruction of the session is stored somewhere outside I think, so it disregards the token or does not attempt to connect using it.

So let's ensure the existence of the keyring before actually starting Slack.

Yes, this is kind of an upstream bug, but we can "fix" this up in our scripts.