### PR TITLE
Drop libsecret module

### DIFF
--- a/com.slack.Slack.yaml
+++ b/com.slack.Slack.yaml
@@ -33,25 +33,6 @@ modules:
   - shared-modules/lzo/lzo.json
   - shared-modules/squashfs-tools/squashfs-tools.json
 
-  - name: libsecret
-    buildsystem: meson
-    config-opts:
-      # Context on disabling crypto: https://gitlab.gnome.org/GNOME/libsecret/-/issues/58
-      - -Dcrypto=disabled
-      - -Dgtk_doc=false
-      - -Dintrospection=false
-      - -Dmanpage=false
-      - -Dvapi=false
-    cleanup:
-      - /bin
-      - /include
-      - /lib/pkgconfig
-      - /share/man
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.7.tar.xz
-        sha256: 6b452e4750590a2b5617adc40026f28d2f4903de15f1250e1d1c40bfd68ed55e
-
   - name: lsb_release
     buildsystem: simple
     cleanup:


### PR DESCRIPTION
org.electronjs.Electron2.BaseApp version 25.08 provides the libsecret module with the following [config-opts](https://github.com/flathub/org.electronjs.Electron2.BaseApp/blob/branch/25.08/org.electronjs.Electron2.BaseApp.yml#L29-L35); therefore, it no longer needs to be compiled (unless the project requires a specific version of this dependency).

Fixes: https://github.com/flathub/com.slack.Slack/issues/367