### PR TITLE
Drop redundant lzo build.

### DIFF
--- a/com.slack.Slack.yaml
+++ b/com.slack.Slack.yaml
@@ -30,7 +30,6 @@ finish-args:
   - --system-talk-name=org.freedesktop.UPower
   - --system-talk-name=org.freedesktop.login1
 modules:
-  - shared-modules/lzo/lzo.json
   - shared-modules/squashfs-tools/squashfs-tools.json
 
   - name: lsb_release


### PR DESCRIPTION
Lzo is pulled as a submodule by squashfs-tools.
This causes lzo to be built twice.