### PR TITLE
Use the lzo module from the runtime

### DIFF
--- a/com.slack.Slack.yaml
+++ b/com.slack.Slack.yaml
@@ -30,7 +30,6 @@ finish-args:
   - --system-talk-name=org.freedesktop.UPower
   - --system-talk-name=org.freedesktop.login1
 modules:
-  - shared-modules/lzo/lzo.json
   - shared-modules/squashfs-tools/squashfs-tools.json
 
   - name: lsb_release


### PR DESCRIPTION
Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10 and 5.15-25.08) provides the lzo module.

Fixes: https://github.com/flathub/com.slack.Slack/issues/370