### PR TITLE
Replace patch-desktop-filename with patch-electron-desktop-filename

### DIFF
--- a/com.slack.Slack.yaml
+++ b/com.slack.Slack.yaml
@@ -86,4 +86,4 @@ modules:
           - unsquashfs -quiet -no-progress slack.snap usr/lib/slack
           - mv squashfs-root/usr/lib/slack/* .
           - rm -r squashfs-root slack.snap
-          - FLATPAK_ID=com.slack.Slack patch-desktop-filename resources/app.asar
+          - patch-electron-desktop-filename --desktop-filename com.slack.Slack --skip-integrity-check resources/app.asar


### PR DESCRIPTION
`patch-desktop-filename` is deprecated and will be removed in 26.08. It's replaced by `patch-electron-desktop-filename`. See flathub/org.electronjs.Electron2.BaseApp#65 for details.

I can confirm that it starts. I didn't test further, as I don't use Slack.

Note:
I needed to disable the integrity check, as the checksum for `focusassist.node` does not match.