### PR TITLE
fix (slack.sh): quote variable expansions to handle paths with spaces

### DIFF
--- a/slack.sh
+++ b/slack.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-env TMPDIR=${XDG_CACHE_HOME} XDG_DOWNLOAD_DIR=$(xdg-user-dir DOWNLOAD) zypak-wrapper /app/extra/slack -s "$@"
+env TMPDIR="${XDG_CACHE_HOME}" XDG_DOWNLOAD_DIR="$(xdg-user-dir DOWNLOAD)" zypak-wrapper /app/extra/slack -s "$@"


### PR DESCRIPTION
## Summary

Quote the `XDG_CACHE_HOME` and `xdg-user-dir DOWNLOAD` expansions in the launcher script so `env(1)` does not word-split them. Without this, Slack fails to launch on systems where these paths contain whitespace.

## The bug

`slack.sh` currently runs:

```bash
env TMPDIR=${XDG_CACHE_HOME} XDG_DOWNLOAD_DIR=$(xdg-user-dir DOWNLOAD) zypak-wrapper /app/extra/slack -s "$@"
```

`env` parses each `NAME=VALUE` argument as a single token. Because the substitutions are unquoted, the shell word-splits the result before `env` sees it. When `xdg-user-dir DOWNLOAD` returns a path containing a space, the second word becomes a positional argument and `env` tries to `execvp` it.

## Reproduction

On Icelandic locale (`is_IS.UTF-8`), `xdg-user-dirs` produces:

```
$ xdg-user-dir DOWNLOAD
/home/$USER/Sóttar skrár
```

Result:

```
$ flatpak run com.slack.Slack
env: 'skrár': No such file or directory
```

Slack never starts. Same class of failure reported in #313 (`env: 'Temp/Google': No such file or directory`) and contributing to several reports in #52 from users with localized download folder names (Romanian `Descărcări`, etc.).

## Fix

```diff
-env TMPDIR=${XDG_CACHE_HOME} XDG_DOWNLOAD_DIR=$(xdg-user-dir DOWNLOAD) zypak-wrapper /app/extra/slack -s "$@"
+env TMPDIR="${XDG_CACHE_HOME}" XDG_DOWNLOAD_DIR="$(xdg-user-dir DOWNLOAD)" zypak-wrapper /app/extra/slack -s "$@"
```

Quoting both expansions makes them single arguments regardless of internal whitespace. Behaviour for paths without spaces is unchanged.

## Verification

Tested locally on Ubuntu 25.10 (kernel 6.17) with `is_IS.UTF-8` locale and `XDG_DOWNLOAD_DIR=\"\$HOME/Sóttar skrár\"`. With the patch applied, Slack launches normally; without it, `env` fails as above.

## Note
This PR and fix was AI assisted