### PR TITLE
Sync beta with master

### DIFF
--- a/com.slack.Slack.yaml
+++ b/com.slack.Slack.yaml
@@ -1,8 +1,8 @@
 app-id: com.slack.Slack
 base: org.electronjs.Electron2.BaseApp
-base-version: '24.08'
+base-version: '25.08'
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: com.slack.Slack
 separate-locales: false
@@ -12,7 +12,8 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=wayland
 
   # Filesystems
   - --filesystem=xdg-download
@@ -30,27 +31,7 @@ finish-args:
   - --system-talk-name=org.freedesktop.UPower
   - --system-talk-name=org.freedesktop.login1
 modules:
-  - shared-modules/lzo/lzo.json
   - shared-modules/squashfs-tools/squashfs-tools.json
-
-  - name: libsecret
-    buildsystem: meson
-    config-opts:
-      # Context on disabling crypto: https://gitlab.gnome.org/GNOME/libsecret/-/issues/58
-      - -Dcrypto=disabled
-      - -Dgtk_doc=false
-      - -Dintrospection=false
-      - -Dmanpage=false
-      - -Dvapi=false
-    cleanup:
-      - /bin
-      - /include
-      - /lib/pkgconfig
-      - /share/man
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.4.tar.xz
-        sha256: 163d08d783be6d4ab9a979ceb5a4fecbc1d9660d3c34168c581301cd53912b20
 
   - name: lsb_release
     buildsystem: simple
@@ -107,4 +88,5 @@ modules:
           - unsquashfs -quiet -no-progress slack.snap usr/lib/slack
           - mv squashfs-root/usr/lib/slack/* .
           - rm -r squashfs-root slack.snap
-          - FLATPAK_ID=com.slack.Slack patch-desktop-filename resources/app.asar
+          - patch-electron-desktop-filename --desktop-filename com.slack.Slack --skip-integrity-check
+            resources/app.asar

--- a/slack.sh
+++ b/slack.sh
@@ -1,12 +1,3 @@
 #!/bin/bash
 
-WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
-
-EXTRA_ARGS='--enable-features=WebRTCPipeWireCapturer'
-
-if [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
-then
-    EXTRA_ARGS="${EXTRA_ARGS} --enable-wayland-ime --ozone-platform-hint=auto --wayland-text-input-version=3"
-fi
-
-env TMPDIR=${XDG_CACHE_HOME} XDG_DOWNLOAD_DIR=$(xdg-user-dir DOWNLOAD) zypak-wrapper /app/extra/slack -s ${EXTRA_ARGS} "$@"
+env TMPDIR="${XDG_CACHE_HOME}" XDG_DOWNLOAD_DIR="$(xdg-user-dir DOWNLOAD)" zypak-wrapper /app/extra/slack -s "$@"


### PR DESCRIPTION
Brings the beta branch in line with master, which resolves the `runtime-update-available-to-org.freedesktop.Platform-25.08` linter warning reported on #390.

The branch-specific bits are deliberately left untouched: the snap checker stays on `channel: beta`, and `flathub.json` keeps the external data checker enabled. After this, beta differs from master only in those two settings.

### Changes

Each mirrors a commit already on master:

* update runtime and base versions to 25.08 (ee46ae6)
* update shared-modules to 8d705c8 (ee46ae6)
* drop libsecret module — provided by `org.electronjs.Electron2.BaseApp` 25.08 (35b691d, fixes #367)
* drop redundant lzo build — pulled as a submodule by squashfs-tools (#369)
* replace `patch-desktop-filename` with `patch-electron-desktop-filename` (#373)
* default to enabling Wayland; Slack has defaulted to Wayland since 4.47.69 (548cdb4, 98d4cb8)

### Verification

Built locally with `flatpak-builder` against runtime 25.08 (exit 0):

* `flatpak-builder-lint manifest` output is now identical to master's — the runtime warning is gone.
* `liblzo2` is still installed to `/app/lib` via squashfs-tools' nested module, and `unsquashfs` extracts the snap correctly.
* Dropping libsecret does not affect the build; the base app supplies it.
* `apply_extra` was replicated against the 4.51.180 snap: `patch-electron-desktop-filename` patches the asar to `"desktopName":"com.slack.Slack.desktop"`, matching the currently published stable build byte for byte.

The pre-existing `module-lsb_release-source-git-no-commit-with-tag` warning is unaffected and still applies to master as well.